### PR TITLE
Do not pin random_compat version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^5.5.9 || ^7.0",
         "ext-zlib": "*",
         "psr/http-message": "^1.0",
-        "paragonie/random_compat": ">=1 <9.99",
+        "paragonie/random_compat": "*",
         "symfony/finder": "^3.0|^4.0|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 

There's no reason to fix random_compat to any version.